### PR TITLE
set fusion_sonar_threshold values to 1 by default. Updated comparison operators

### DIFF
--- a/apps-javascript/fusion-cdn-avoid-bursting+sonar/app.js
+++ b/apps-javascript/fusion-cdn-avoid-bursting+sonar/app.js
@@ -47,7 +47,8 @@ var handler = new OpenmixApplication({
     error_ttl: 20,
     min_valid_rtt_score: 5,
     availability_threshold: 90,
-    fusion_sonar_threshold: 2,
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1,
     //set it true if you want to filter the candidates by avail techniques, otherwise set it to false
     //both options can be set to true or false.
     use_radar_avail: true,
@@ -193,7 +194,7 @@ function OpenmixApplication(settings) {
         function filterFusionSonar(candidate, alias) {
             return dataFusion[candidate.sonar] !== undefined &&
                 dataFusion[candidate.sonar].health_score !== undefined &&
-                (dataFusion[candidate.sonar].health_score.value > settings.fusion_sonar_threshold || dataFusion[candidate.sonar].availability_override !== undefined );
+                (dataFusion[candidate.sonar].health_score.value >= settings.fusion_sonar_threshold || dataFusion[candidate.sonar].availability_override !== undefined );
         }
 
         /**

--- a/apps-javascript/fusion-cdn-avoid-bursting+sonar/test/tests.js
+++ b/apps-javascript/fusion-cdn-avoid-bursting+sonar/test/tests.js
@@ -644,7 +644,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 2
+                            "value": 0
                         },
                         "bypass_data_points": true
                     }),
@@ -653,7 +653,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 1
+                            "value": 0
                         },
                         "bypass_data_points": true
                     })
@@ -732,7 +732,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 2
+                            "value": 0
                         },
                         "bypass_data_points": true
                     }),
@@ -820,7 +820,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 2
+                            "value": 0
                         },
                         "bypass_data_points": true
                     }),
@@ -963,7 +963,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 4
+                            "value": 5
                         },
                         "bypass_data_points": true,
                         "availability_override": true
@@ -1108,7 +1108,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 4
+                            "value": 5
                         },
                         "bypass_data_points": true
                     }),
@@ -1251,7 +1251,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 1
+                            "value": 0
                         },
                         "bypass_data_points": true
                     }),
@@ -1260,7 +1260,7 @@
                         "state": "OK",
                         "health_score": {
                             "unit": "0-5",
-                            "value": 1
+                            "value": 0
                         },
                         "bypass_data_points": true
                     })

--- a/apps-javascript/geo-with-overrides+sonar/app.js
+++ b/apps-javascript/geo-with-overrides+sonar/app.js
@@ -27,9 +27,8 @@ var handler = new OpenmixApplication({
     error_ttl: 20,
     // flip to true if the platform will be considered unavailable if it does not have sonar data
     require_sonar_data: false,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -86,7 +85,7 @@ function OpenmixApplication(settings) {
          */
         function belowSonarThreshold(alias) {
             if (dataFusion[alias] !== undefined && dataFusion[alias].health_score !== undefined && dataFusion[alias].availability_override === undefined) {
-                return dataFusion[alias].health_score.value <= settings.fusion_sonar_threshold;
+                return dataFusion[alias].health_score.value < settings.fusion_sonar_threshold;
             }
             return settings.require_sonar_data;
         }

--- a/apps-javascript/multi-geo-round-robin-with-overrides+sonar/app.js
+++ b/apps-javascript/multi-geo-round-robin-with-overrides+sonar/app.js
@@ -29,9 +29,8 @@ var handler = new OpenmixApplication({
     // country_to_provider_roundrobin: { 'UK': ['bar','foo'], 'ES': ['baz','faa']},
     // flip to true if the platform will be considered unavailable if it does not have sonar data
     require_sonar_data: false,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -81,14 +80,14 @@ function OpenmixApplication(settings) {
             no_passed_candidates_default_selected: 'D'
         };
 
-        // determine which providers have a sonar value above threshold
+        // determine which providers have a sonar value on or above threshold
         /**
          * @param alias
          * @returns {boolean}
          */
         function aboveSonarThreshold(alias) {
             if (dataFusion[alias] !== undefined && dataFusion[alias].health_score !== undefined && dataFusion[alias].availability_override === undefined) {
-                return dataFusion[alias].health_score.value > settings.fusion_sonar_threshold;
+                return dataFusion[alias].health_score.value >= settings.fusion_sonar_threshold;
             }
             return !settings.require_sonar_data;
         }
@@ -110,7 +109,7 @@ function OpenmixApplication(settings) {
             // Else origin
         } else {
             // Check origin sonar decision
-            if (dataFusion.origin !== undefined && dataFusion.origin.health_score.value > settings.fusion_sonar_threshold && dataFusion.origin.availability_override === undefined) {
+            if (dataFusion.origin !== undefined && dataFusion.origin.health_score.value >= settings.fusion_sonar_threshold && dataFusion.origin.availability_override === undefined) {
                 decisionProvider = 'origin';
                 decisionReason = allReasons.default_selected;
             } else {

--- a/apps-javascript/ortt+RAXsonar/app.js
+++ b/apps-javascript/ortt+RAXsonar/app.js
@@ -18,9 +18,8 @@ var handler = new OpenmixApplication({
     default_ttl: 20,
     // The minimum availability score that providers must have in order to be considered available
     availability_threshold: 90,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -76,7 +75,7 @@ function OpenmixApplication(settings) {
          * @param key
          */
         function filterFusionSonar(candidate, key) {
-            return dataFusion[key] !== undefined && dataFusion[key].health_score !== undefined && dataFusion[key].health_score.value > settings.fusion_sonar_threshold;
+            return dataFusion[key] !== undefined && dataFusion[key].health_score !== undefined && dataFusion[key].health_score.value >= settings.fusion_sonar_threshold;
         }
 
         /**

--- a/apps-javascript/ortt+sonar/app.js
+++ b/apps-javascript/ortt+sonar/app.js
@@ -16,9 +16,8 @@ var handler = new OpenmixApplication({
     // when set true if one of the provider has not data it will be removed,
     // when set to false, sonar data is optional, so a provider with no sonar data will be used
     require_sonar_data: true,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -82,7 +81,7 @@ function OpenmixApplication(settings) {
         function filterSonar(alias) {
             // let the flag determine if the provider is available when we don't have sonar data for the provider
             if (dataFusion[alias] !== undefined && dataFusion[alias].health_score !== undefined && dataFusion[alias].availability_override === undefined) {
-                return dataFusion[alias].health_score.value > settings.fusion_sonar_threshold;
+                return dataFusion[alias].health_score.value >= settings.fusion_sonar_threshold;
             }
             return !settings.require_sonar_data;
         }

--- a/apps-javascript/perf-avail-sonar/app.js
+++ b/apps-javascript/perf-avail-sonar/app.js
@@ -13,9 +13,8 @@ var handler = new OpenmixApplication({
     default_provider: 'foo',
     default_ttl: 20,
     availability_threshold: 80,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -73,7 +72,7 @@ function OpenmixApplication(settings) {
             // Filter sonar and radar availability
             return dataFusion[key] !== undefined
                 && dataFusion[key].health_score !== undefined
-                && dataFusion[key].health_score.value > settings.fusion_sonar_threshold
+                && dataFusion[key].health_score.value >= settings.fusion_sonar_threshold
                 && dataAvail[key] !== undefined
                 && dataAvail[key].avail >= settings.availability_threshold;
         }

--- a/apps-javascript/round-robin-failover/app.js
+++ b/apps-javascript/round-robin-failover/app.js
@@ -24,9 +24,8 @@ var handler = new OpenmixApplication({
     default_provider: 'foo',
     // The TTL to be set when the application chooses a geo provider.
     default_ttl: 20,
-    // Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -88,7 +87,7 @@ function OpenmixApplication(settings) {
          */
         function filterPrimaryCandidates(alias) {
             return dataFusion[alias] !== undefined && dataFusion[alias].health_score !== undefined
-                && dataFusion[alias].health_score.value > settings.fusion_sonar_threshold
+                && dataFusion[alias].health_score.value >= settings.fusion_sonar_threshold
                 && (settings.providers[alias] !== undefined);
         }
 
@@ -98,7 +97,7 @@ function OpenmixApplication(settings) {
          */
         function filterFailoverCandidates(alias) {
             return dataFusion[alias] !== undefined && dataFusion[alias].health_score !== undefined
-                && dataFusion[alias].health_score.value > settings.fusion_sonar_threshold
+                && dataFusion[alias].health_score.value >= settings.fusion_sonar_threshold
                 && (settings.failover_providers[alias] !== undefined);
         }
 

--- a/apps-javascript/throughput-avail-sonar/app.js
+++ b/apps-javascript/throughput-avail-sonar/app.js
@@ -13,9 +13,8 @@ var handler = new OpenmixApplication({
     default_provider: 'foo',
     default_ttl: 20,
     availability_threshold: 80,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -73,7 +72,7 @@ function OpenmixApplication(settings) {
             // Filter sonar and radar availability
             return dataFusion[key] !== undefined
                 && dataFusion[key].health_score !== undefined
-                && dataFusion[key].health_score.value > settings.fusion_sonar_threshold
+                && dataFusion[key].health_score.value >= settings.fusion_sonar_threshold
                 && dataAvail[key] !== undefined
                 && dataAvail[key].avail >= settings.availability_threshold;
         }

--- a/apps-javascript/weighted-round-robin-with-sonar/app.js
+++ b/apps-javascript/weighted-round-robin-with-sonar/app.js
@@ -27,9 +27,8 @@ var handler = new OpenmixApplication({
 
     // The DNS TTL to be applied to DNS responses in seconds.
     default_ttl: 20,
-    //Set Fusion Sonar threshold for availability for the platform to be included.
-    // sonar values are between 0 - 5
-    fusion_sonar_threshold: 2
+    // To enforce a Sonar health-check, set this threshold value to 1. To ignore the health-check, set this value to 0.
+    fusion_sonar_threshold: 1
 });
 
 function init(config) {
@@ -88,7 +87,7 @@ function OpenmixApplication(settings) {
          * @param key
          */
         function filterFusionSonar(candidate, key) {
-            return dataFusion[key] !== undefined && dataFusion[key].health_score !== undefined && dataFusion[key].health_score.value > settings.fusion_sonar_threshold;
+            return dataFusion[key] !== undefined && dataFusion[key].health_score !== undefined && dataFusion[key].health_score.value >= settings.fusion_sonar_threshold;
         }
 
         /**

--- a/apps-javascript/weighted-round-robin-with-sonar/app.js
+++ b/apps-javascript/weighted-round-robin-with-sonar/app.js
@@ -136,7 +136,7 @@ function OpenmixApplication(settings) {
             //check if "Big Red Button" isn't activated
             if (dataFusion[dataFusionAliases[0]].availability_override === undefined) {
                 // filter candidates by  fusion sonar threshold,
-                // remove all the provider with fusion sonar data <= than settings.fusion_sonar_threshold
+                // remove all the provider with fusion sonar data < than settings.fusion_sonar_threshold
                 candidates = filterObject(dataFusion, filterFusionSonar);
                 candidateAliases = Object.keys(candidates);
 


### PR DESCRIPTION
So, I believe this is correct. I haven't tested it out, but the gist of it is updating the fusion_sonar_threshold to be either "1", or "0".

If the value is "1", then enforce Sonar health check. If the value is "0", then ignore the Sonar health check.

I changed the numerical comparison operators to reflect this behavior.

As a side note, all the the existing unit tests pass except for the app **fusion-cdn-avoid-bursting+sonar**. There are some tests that do not pass, this one definitely needs to be updated, however not sure if other unit tests need to change as well.